### PR TITLE
report other metrics that can compensate first-paint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ Web-site performance is a crucial factor to succeeding in the Web business.
 According to [a research conducted by Microsoft](http://radar.oreilly.com/2009/07/velocity-making-your-site-fast.html), 500msec slowdown in Bing causes their revenue go down by 1.2%.
 
 Wpbench collects the following metrics required for tuning the performance.
-The primary goal of performance tuning will be to minimize _first-paint_ time, so that the visitors to the web site can start working on the destination page as early as possible, and the second goal will be the _load_ time.
+The primary goal of performance tuning will be to provide _some_ visible response to user so that they can start working on, and the second goal will be the _load_ time.
 
 Event | Description 
 ----- | -----------
-unload | timing when the browser switches to the destination page; the new page will be blank until
-first-paint | timing when some content of the destination page is rendered by the web browser
+unload | timing when the browser switches to the destination page (which will be blank at this moment)
+parsed &lt;head&gt; | when parsing of &lt;head&gt; completes (indicates that all scripts in head have been loaded)
+loaded CSS in &lt;head&gt; | when all the stylesheets in &lt;head&gt; have been loaded; this is essentially when the browser becomes capable of rendering something
 DOMContentLoaded | timing when the entier HTML is laid out
 load | timing when all the downloads are complete
 

--- a/wpbench.html
+++ b/wpbench.html
@@ -1,5 +1,48 @@
 <title>wpbench</title>
 <script>
+function absurl(doc, href) {
+    var a = doc.createElement("a");
+    a.href = href;
+    return a.href;
+}
+
+function cssIsReady(doc, href) {
+    var i, sheets = doc.styleSheets;
+    for (i = 0; i != sheets.length; ++i) {
+        if (sheets[i].href == href)
+            return true;
+    }
+    return false;
+}
+
+function getStyleRefs(doc) {
+    var refs = [];
+    var nodesInHead = doc.head.childNodes;
+    for (var i = 0; i != nodesInHead.length; ++i) {
+        var node = nodesInHead[i];
+        if (node.nodeType != 1)
+            continue;
+        if (node.tagName.match(/^link$/i) == null)
+            continue;
+        if ((t = node.getAttribute("rel")) == null || t.match(/^\s*stylesheet\s*$/i) == null)
+            continue;
+        if ((t = node.getAttribute("media")) != null && t.match(/^\s*(all|screen)\s*$/i) == null)
+            continue;
+        if ((t = node.getAttribute("href")) == null)
+            continue;
+        refs.push(absurl(doc, t));
+    }
+    return refs;
+}
+
+function allCSSAreReady(doc, refs) {
+    for (var i = 0; i != refs.length; ++i) {
+        if (!cssIsReady(doc, refs[i]))
+            return false;
+    }
+    return true;
+}
+
 function start() {
     var resultElement = document.getElementById("result");
     var targetElement = document.getElementById("testframe");
@@ -19,27 +62,46 @@ function start() {
         }
     })();
 
+    var pollTimers = (function () {
+        var styleRefs = null;
+        var waitForCSS = function () {
+            if (styleRefs == null)
+                styleRefs = getStyleRefs(targetElement.contentDocument);
+            if (allCSSAreReady(targetElement.contentDocument, styleRefs)) {
+                resultElement.value += "loaded CSS in <head>: " + elapsed() + " msec\n";
+                return;
+            }
+            setTimeout(waitForCSS, 10);
+        };
+        var waitForBody = function () {
+            if (targetElement.contentDocument.body != null) {
+                resultElement.value += "parsed <head>: " + elapsed() + " msec\n";
+                if (navigator.userAgent.match(/Firefox\//) == null)
+                    waitForCSS();
+                return;
+            }
+            setTimeout(waitForBody, 10);
+        };
+        return waitForBody;
+    })();
+
     targetElement.contentWindow.addEventListener("unload", function () {
         resultElement.value += "unload: " + elapsed() + " msec\n";
+        setTimeout(function () {
+            if (targetElement.contentDocument.location == "about:blank") {
+                alert("failed to wait until unload complete");
+                return;
+            }
+            pollTimers();
+            targetElement.contentWindow.addEventListener("DOMContentLoaded", function () {
+                resultElement.value += "DOMContentLoaded: " + elapsed() + " msec\n";
+            });
+            targetElement.contentWindow.addEventListener("load", function () {
+                resultElement.value += "load: " + elapsed() + " msec\n";
+            });
+        }, 0);
     });
-
     targetElement.contentDocument.location = document.getElementById("target-path").value;
-
-    var cb = function () {
-        var doc = targetElement.contentDocument;
-        if (doc.location == "about:blank" || doc.body == null || doc.body.clientHeight == 0) {
-            setTimeout(cb, 10);
-            return;
-        }
-        resultElement.value += "first-paint: " + elapsed() + " msec\n";
-        targetElement.contentWindow.addEventListener("DOMContentLoaded", function () {
-            resultElement.value += "DOMContentLoaded: " + elapsed() + " msec\n";
-        });
-        targetElement.contentWindow.addEventListener("load", function () {
-            resultElement.value += "load: " + elapsed() + " msec\n";
-        });
-    };
-    setTimeout(cb, 10);
 }
 </script>
 <body>


### PR DESCRIPTION
As pointed out and discussed in #1, the tool has so far been failing to report correct value of first-paint, and that it would be hard to provide such metric on all browsers.

Considering the fact, this PR does the following:
- do not report first-paint
  - we should better report this for browsers that provide access to the value
- report two new metrics:
  - `parsed <head>` reports when parsing of `<head>` completes (= when `document.body` becomes non-null); this metric is useful as it is a sign that all the `<scripts>` have been loaded
  - `loaded CSS in <head>` reports when all the CSS referred from `<head>` has become available; this would be essentially the first-paint time in many cases

note: the latter of the two new metrics is not reported in Firefox, since there is no way to determine the timing when using the browser.
